### PR TITLE
chore: bump default apiserver to v0.0.10

### DIFF
--- a/docs/kplane-cli-design.md
+++ b/docs/kplane-cli-design.md
@@ -36,7 +36,7 @@ kplane up
   --provider kind
   --cluster-name kplane-management
   --namespace kplane-system
-  --apiserver-image docker.io/kplanedev/apiserver:v0.0.9
+  --apiserver-image docker.io/kplanedev/apiserver:v0.0.10
   --operator-image docker.io/kplanedev/controlplane-operator:v0.0.3
   --etcd-image quay.io/coreos/etcd:v3.5.13
   --install-crds
@@ -192,7 +192,7 @@ profiles:
     kubeconfigPath: ~/.kube/config
     stackVersion: latest
     images:
-      apiserver: docker.io/kplanedev/apiserver:v0.0.9
+      apiserver: docker.io/kplanedev/apiserver:v0.0.10
       operator: docker.io/kplanedev/controlplane-operator:v0.0.3
       etcd: quay.io/coreos/etcd:v3.5.13
     auth:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,7 +77,7 @@ func Default() Config {
 				StackVersion:   "latest",
 				CRDSource:      "https://github.com/kplane-dev/controlplane-operator//config/crd?ref=main",
 				Images: Images{
-					Apiserver: "docker.io/kplanedev/apiserver:v0.0.9",
+					Apiserver: "docker.io/kplanedev/apiserver:v0.0.10",
 					Operator:  "docker.io/kplanedev/controlplane-operator:v0.0.15",
 					Etcd:      "quay.io/coreos/etcd:v3.5.13",
 				},
@@ -204,7 +204,8 @@ func isDefaultApiserverImage(image string) bool {
 		"docker.io/kplanedev/apiserver:v0.0.6",
 		"docker.io/kplanedev/apiserver:v0.0.7",
 		"docker.io/kplanedev/apiserver:v0.0.8",
-		"docker.io/kplanedev/apiserver:v0.0.9":
+		"docker.io/kplanedev/apiserver:v0.0.9",
+		"docker.io/kplanedev/apiserver:v0.0.10":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
- Bump default apiserver image to `docker.io/kplanedev/apiserver:v0.0.10`
- Add `v0.0.10` to the recognized default image set so `ApplyDefaultImageUpgrades` can cleanly upgrade configs pinned to older default versions
- Update docs/kplane-cli-design.md to reference the new version
